### PR TITLE
Add gh auth

### DIFF
--- a/dot_colima/default/colima.yaml.tmpl
+++ b/dot_colima/default/colima.yaml.tmpl
@@ -7,7 +7,7 @@ rosetta: true       # Allow x86_64 binaries in arm64 VM
 
 cpu: 4              # Default 2 → 4 for smoother dev
 memory: 8           # Default 2 → 8 GiB
-disk: 60            # Default 100 → 60 GiB (can only increase later)
+disk: 100            # Default 100 → 60 GiB (can only increase later)
 
 runtime: docker     # Keep Docker engine
 

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,6 +1,6 @@
 # Purpose: Neon, slightly transparent macOS look. Has a local include for per-host tweaks.
-# theme=RetroLegends
-theme=CGA
+theme=RetroLegends
+# theme=CGA
 # theme=Blue Matrix
 # Font (choose one; SF Mono Nerd Font gives native look with icons)
 # font-family = FiraCode Nerd Font

--- a/dot_config/zsh/shrc.d/20-openai.sh.tmpl
+++ b/dot_config/zsh/shrc.d/20-openai.sh.tmpl
@@ -1,0 +1,6 @@
+# Export OPENAI_API_KEY from macOS Keychain (no prompt)
+{{ if .profile.dev -}}
+if command -v security >/dev/null 2>&1; then
+  export OPENAI_API_KEY="$(security find-generic-password -a "${USER}" -s "openai_api_key" -w 2>/dev/null || true)"
+fi
+{{- end }}

--- a/dot_docker/config.json.tmpl
+++ b/dot_docker/config.json.tmpl
@@ -1,6 +1,9 @@
 {
   "cliPluginsExtraDirs": [
-    "{{ (output "brew" "--prefix") }}/lib/docker/cli-plugins",
+    "{{ (output "brew" "--prefix" | trim) }}/lib/docker/cli-plugins",
     "{{ .chezmoi.homeDir }}/.docker/cli-plugins"
-  ]
+  ],
+  "credsStore": "osxkeychain",
+  "detachKeys": "ctrl-@,ctrl-@",
+  "plugins": {}
 }

--- a/dot_ssh/config.tmpl
+++ b/dot_ssh/config.tmpl
@@ -1,0 +1,6 @@
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+  ServerAliveInterval 60
+  ServerAliveCountMax 3

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -125,6 +125,15 @@ alias old_ls='command ls'                                             # real BSD
 command -v lazygit    >/dev/null 2>&1 && alias lg='lazygit'
 command -v lazydocker >/dev/null 2>&1 && alias lzd='lazydocker'
 
+
+# ---- Load custom shrc.d snippets -----------------------------
+# This lets chezmoi-managed files in ~/.config/zsh/shrc.d run automatically.
+# Files are executed in lexical order (10-foo.sh, 20-bar.sh, etc.)
+if [ -d "${XDG_CONFIG_HOME:-$HOME/.config}/zsh/shrc.d" ]; then
+  for file in "${XDG_CONFIG_HOME:-$HOME/.config}/zsh/shrc.d"/*.sh; do
+    [ -r "$file" ] && source "$file"
+  done
+fi
 # ---- (Optional) GPG pinentry on macOS -------------------------------
 # If you brewed pinentry-mac, uncomment to use a GUI prompt:
 # if command -v pinentry-mac >/dev/null 2>&1; then

--- a/run_once_before_20-github-ssh-auth.sh.tmpl
+++ b/run_once_before_20-github-ssh-auth.sh.tmpl
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# run_once_before_20-github-ssh-auth.sh.tmpl
+# Generates an SSH key, loads it, optionally helps you log into GitHub,
+# then uploads the public key. Idempotent and headless-safe.
+set -euo pipefail
+[[ "{{ if .profile.core }}1{{ else }}0{{ end }}" = "1" ]] || exit 0
+
+log() { printf "\033[1;32m[gh-ssh]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[gh-ssh]\033[0m %s\n" "$*"; }
+
+GH_HOST="${GH_HOST:-github.com}"
+KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+PUB="${KEY}.pub"
+TITLE="{{ .chezmoi.hostname }}:{{ .chezmoi.username }}"
+
+# 0) Preconditions
+if ! command -v gh >/dev/null 2>&1; then
+  warn "gh not found (expected preinstalled). Skipping GitHub upload."
+fi
+
+# 1) Tight ~/.ssh perms
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+
+# 2) Ensure key (Ed25519)
+if [[ ! -f "$KEY" ]]; then
+  EMAIL="$(git config --global user.email || true)"
+  [[ -z "$EMAIL" ]] && EMAIL="${USER}@$(hostname -s)"
+  log "Generating SSH key: $KEY"
+  ssh-keygen -t ed25519 -C "$EMAIL" -f "$KEY" -N ""
+else
+  log "SSH key already exists at $KEY."
+fi
+
+# 3) Add to agent (macOS uses keychain)
+eval "$(ssh-agent -s)" >/dev/null
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  ssh-add --apple-use-keychain "$KEY" || true
+else
+  ssh-add "$KEY" || true
+fi
+log "SSH key loaded into ssh-agent."
+
+# 4) Ensure gh auth
+if command -v gh >/dev/null 2>&1; then
+  if ! gh auth status -h "$GH_HOST" >/dev/null 2>&1; then
+    # Non-interactive fast path with GH_TOKEN, if present.
+    if [[ -n "${GH_TOKEN:-}" ]]; then
+      printf '%s' "$GH_TOKEN" | gh auth login -h "$GH_HOST" --with-token >/dev/null 2>&1 || true
+    fi
+  fi
+
+  if ! gh auth status -h "$GH_HOST" >/dev/null 2>&1; then
+    # Interactive help only if a real terminal is attached.
+    if [[ -t 0 && -t 1 && "${GH_INTERACTIVE_LOGIN:-1}" = "1" ]]; then
+      warn "GitHub CLI is not authenticated for $GH_HOST."
+      printf "Open browser and authenticate now? [Y/n]: "
+      read -r ans || ans=""
+      case "${ans,,}" in
+      n | no) ;;
+      *) gh auth login --web -h "$GH_HOST" --git-protocol ssh || true ;;
+      esac
+    else
+      warn "Not authenticated. Run once and re-apply:
+  gh auth login --web -h \"$GH_HOST\" --git-protocol ssh"
+    fi
+  fi
+fi
+
+# 5) Upload key if authed (idempotent)
+if command -v gh >/dev/null 2>&1 && gh auth status -h "$GH_HOST" >/dev/null 2>&1; then
+  if gh ssh-key add "$PUB" --title "$TITLE" 2> >(tee /tmp/gh_ssh_add.err >&2); then
+    log "Uploaded SSH public key to $GH_HOST (title: $TITLE)."
+  elif grep -qi "already in use" /tmp/gh_ssh_add.err; then
+    log "Public key already present on $GH_HOST; skipping."
+  else
+    warn "Could not upload key automatically. Run:
+  gh ssh-key add \"$PUB\" --title \"$TITLE\" -h \"$GH_HOST\""
+  fi
+fi
+
+# 6) SSH connectivity check (non-fatal)
+if ssh -o BatchMode=yes -T "git@${GH_HOST}" 2>&1 | grep -q "successfully authenticated"; then
+  log "SSH to $GH_HOST works."
+else
+  warn "SSH to $GH_HOST not verified yet (likely before auth or key approval). Try:
+  ssh -T git@${GH_HOST}"
+fi

--- a/run_once_before_30-docker-auth.sh.tmpl
+++ b/run_once_before_30-docker-auth.sh.tmpl
@@ -1,0 +1,113 @@
+{{- /* macOS only, gated by profile.dev; assumes credsStore=osxkeychain already set */ -}}
+{{- if and (eq .chezmoi.os "darwin") (.profile.dev) -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+log()  { printf "\033[1;34m[dev-auth]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[warn]\033[0m %s\n" "$*"; }
+err()  { printf "\033[1;31m[error]\033[0m %s\n" "$*" >&2; }
+
+# ---- guards -----------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  warn "docker not found; skipping container auth."
+  exit 0
+fi
+
+
+# ---- helper: check if docker is logged in to Docker Hub ---------------------
+is_dockerhub_logged_in() {
+  docker info 2>/dev/null | grep -qE '^ Username:[[:space:]]+\S+'
+}
+
+# ---- Docker Hub login (interactive → Keychain) ------------------------------
+if ! is_dockerhub_logged_in; then
+  cat <<'NOTE'
+You are not logged in to Docker Hub.
+- Username: your Docker ID
+- Password: use a Docker Hub **Access Token** (recommended).
+Credentials will be stored securely in macOS Keychain.
+NOTE
+  log "Running: docker login (Docker Hub)"
+  docker login
+  if ! is_dockerhub_logged_in; then
+    err "Docker Hub login failed."
+    exit 1
+  fi
+  log "Docker Hub login OK (stored in Keychain)."
+else
+  log "Docker Hub already logged in."
+fi
+
+# ---- GitHub CLI (gh) for repo + GHCR access --------------------------------
+ensure_gh() {
+  if command -v gh >/dev/null 2>&1; then return 0; fi
+  if ! command -v brew >/dev/null 2>&1; then
+    warn "gh not found and Homebrew missing; skipping GitHub auth."
+    return 1
+  fi
+  log "Installing GitHub CLI (gh)..."
+  brew install gh
+}
+if ensure_gh; then
+  if ! gh auth status >/dev/null 2>&1; then
+    log "GitHub login via device flow (requesting repo, read:packages)..."
+    gh auth login -s "read:packages,repo" -w || {
+      err "GitHub auth failed."
+      exit 1
+    }
+  else
+    if ! gh auth status -t 2>/dev/null | grep -q "read:packages"; then
+      log "Refreshing GitHub token scopes to include read:packages..."
+      gh auth refresh -s "read:packages,repo" -h github.com || {
+        err "Failed to refresh GitHub token scopes."
+        exit 1
+      }
+    fi
+  fi
+  log "GitHub auth OK."
+else
+  warn "Skipping GitHub login because gh installation was not possible."
+fi
+
+# ---- Docker login to GitHub Container Registry (ghcr.io) --------------------
+login_ghcr() {
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    GH_USER="$(gh api user --jq .login)"
+    GH_TOKEN="$(gh auth token)"
+    if [[ -n "${GH_USER:-}" && -n "${GH_TOKEN:-}" ]]; then
+      log "Logging into ghcr.io as $GH_USER using gh token..."
+      if echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_USER" --password-stdin; then
+        log "ghcr.io login OK (stored in Keychain)."
+        return 0
+      fi
+    fi
+  fi
+  cat <<'MSG'
+GitHub Container Registry (ghcr.io) login:
+- Username: your GitHub username
+- Password: a GitHub **Personal Access Token** with 'read:packages'
+Credentials will be stored securely in macOS Keychain.
+MSG
+  docker login ghcr.io || return 1
+  log "ghcr.io login OK (stored in Keychain)."
+  return 0
+}
+
+has_ghcr_creds() {
+  # Ask helper whether ghcr.io entry exists
+  if command -v docker-credential-osxkeychain >/dev/null 2>&1; then
+    if printf "list\n" | docker-credential-osxkeychain 2>/dev/null | grep -q '"ghcr.io"'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if has_ghcr_creds; then
+  log "ghcr.io credentials already present in Keychain."
+else
+  login_ghcr || { err "Failed to login to ghcr.io."; exit 1; }
+fi
+
+log "Done: Docker Hub + ghcr.io auth configured; creds are in macOS Keychain."
+{{- end -}}

--- a/run_once_before_40-openai-auth.sh.tmpl
+++ b/run_once_before_40-openai-auth.sh.tmpl
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "{{ if .profile.dev }}1{{ else }}0{{ end }}" = "1" ]] || exit 0
+SERVICE="openai_api_key"
+ACCOUNT="${USER}"
+KEY_URL="https://platform.openai.com/account/api-keys"
+
+# If OPENAI_API_KEY is provided via env, prefer that (non-interactive).
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  security add-generic-password -a "${ACCOUNT}" -s "${SERVICE}" -w "${OPENAI_API_KEY}" -U >/dev/null
+  exit 0
+fi
+
+# Skip if already present
+if security find-generic-password -a "${ACCOUNT}" -s "${SERVICE}" >/dev/null 2>&1; then
+  exit 0
+fi
+
+printf "\033[1;33m[openai]\033[0m No API key found in Keychain.\n"
+printf "→ You can create one here: %s\n" "$KEY_URL"
+
+# Try to launch browser if on macOS
+if command -v open >/dev/null 2>&1; then
+  open "$KEY_URL"
+fi
+
+printf "Enter OpenAI API key (starts with 'sk-'): "
+read -r KEY
+if [[ -n "${KEY}" ]]; then
+  security add-generic-password -a "${ACCOUNT}" -s "${SERVICE}" -w "${KEY}" -U >/dev/null
+  printf "\033[1;32m[openai]\033[0m saved to Keychain.\n"
+else
+  printf "\033[1;33m[openai]\033[0m no key entered; skipping.\n"
+fi


### PR DESCRIPTION
This pull request introduces several improvements to developer environment automation, focusing on secure credential management, streamlined authentication, and enhanced configuration defaults for macOS development. The changes automate the setup of SSH, Docker, GitHub, and OpenAI credentials, improve macOS integration, and add quality-of-life enhancements to shell and terminal configuration.

**Credential Management and Authentication Automation:**

* Added a script to automatically generate and configure SSH keys, load them into the agent, authenticate with GitHub (via `gh` CLI), upload the public key, and verify SSH connectivity. This process is idempotent and designed for headless operation.
* Introduced a script to automate Docker Hub and GitHub Container Registry (`ghcr.io`) authentication on macOS, storing credentials securely in the Keychain and ensuring necessary GitHub token scopes.
* Added a script to prompt for and store the OpenAI API key in the macOS Keychain, with support for non-interactive setup via environment variable.
* Updated shell configuration to automatically export the `OPENAI_API_KEY` from the macOS Keychain during development sessions.

**Configuration and Usability Enhancements:**

* Improved Docker configuration to use the `osxkeychain` credential store, set custom detach keys, and ensure plugin paths are correctly formatted.
* Set up SSH client configuration to always use the keychain, add keys to the agent, and maintain persistent connections.
* Enabled automatic loading of custom shell snippets from `~/.config/zsh/shrc.d` for modular shell configuration.
* Swapped the default terminal theme back to `RetroLegends` for a consistent appearance.
* Increased the default disk size for Colima VMs to 100 GiB for improved development experience.